### PR TITLE
Very small change to pavlov for Windows compatibilty

### DIFF
--- a/pavlov.js
+++ b/pavlov.js
@@ -436,7 +436,7 @@
         // get a string of the fn's parameters
         var params = fn.toString().match(/\(([^\)]*)\)/)[1];
         // get a string of fn's body
-        var source = fn.toString().match(/^[^\{]*\{((.*\n*)*)\}/m)[1];
+        var source = fn.toString().match(/^[^\{]*\{((.*\s*)*)\}/m)[1];
 
         // create a new function with same parameters and
         // body wrapped in a with(extraScope){ }


### PR DESCRIPTION
Hi Michael,

  I have been experimenting with your excellent library on Windows and had a little trouble with one of the regular expressions not working with files I was developing because it expected *nix line endings rather than Windows in the javascript files.

  I think the intention of the expression was to grab the content of the function regardless of any kind of white-space; so changed it to /s from /n.

Cheers,

Paul
