### PR TITLE
Added 'api' to the public API.

### DIFF
--- a/pavlov.js
+++ b/pavlov.js
@@ -601,6 +601,7 @@
             each: util.each,
             extend: util.extend
         },
+        api: api,
         globalApi: false,                 // when true, adds api to global scope
         extendAssertions: addAssertions   // function for adding custom assertions
     };


### PR DESCRIPTION
I'd like to be able to extend the pavlov api to allow syntax like this: https://github.com/dmohl/expectThat
