### PR TITLE
Do not use commas to separate description names.

### DIFF
--- a/pavlov.js
+++ b/pavlov.js
@@ -182,7 +182,7 @@
          * @returns string of joined description names
          */
         names: function () {
-            return rollup(this, 'name').reverse().join(' / ');
+            return rollup(this, 'name').reverse().join(specify.descriptionSeparator);
         }
     });
 
@@ -609,7 +609,8 @@
         },
         api: api,
         globalApi: false,                 // when true, adds api to global scope
-        extendAssertions: addAssertions   // function for adding custom assertions
+        extendAssertions: addAssertions,  // function for adding custom assertions
+        descriptionSeparator: ' / '       // separator used when rolling up names
     };
 }(window));
 

--- a/pavlov.js
+++ b/pavlov.js
@@ -182,7 +182,7 @@
          * @returns string of joined description names
          */
         names: function () {
-            return rollup(this, 'name').reverse().join(', ');
+            return rollup(this, 'name').reverse().join(' / ');
         }
     });
 


### PR DESCRIPTION
Since JsTestDriver does not allow commas in test names this 'quick-n-dirty'
fix is required to allow Pavlov to work in a JsTestDriver environment.

Note: a more sensible approach would be to fix JsTestDriver to not place
restrictions on test names but this seems to be way harder to fix.
