### PR TITLE
Give adapter responsibility for document initialization

### DIFF
--- a/lib/qunit.css
+++ b/lib/qunit.css
@@ -1,13 +1,11 @@
 /**
- * QUnit v1.9.0pre - A JavaScript Unit Testing Framework
+ * QUnit v1.9.0 - A JavaScript Unit Testing Framework
  *
  * http://docs.jquery.com/QUnit
  *
- * Copyright 2012 jQuery Foundation and other contributors
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- * Pulled Live from Git Sat Jul  7 19:20:01 UTC 2012
- * Last Commit: b0c3da8d09b1dcbe5dd0877e27386f4b9e8050a1
+ * Copyright (c) 2012 John Resig, Jörn Zaefferer
+ * Dual licensed under the MIT (MIT-LICENSE.txt)
+ * or GPL (GPL-LICENSE.txt) licenses.
  */
 
 /** Font Family and Sizes */

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -1,13 +1,11 @@
 /**
- * QUnit v1.9.0pre - A JavaScript Unit Testing Framework
+ * QUnit v1.9.0 - A JavaScript Unit Testing Framework
  *
  * http://docs.jquery.com/QUnit
  *
- * Copyright 2012 jQuery Foundation and other contributors
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- * Pulled Live from Git Sat Jul  7 19:20:01 UTC 2012
- * Last Commit: b0c3da8d09b1dcbe5dd0877e27386f4b9e8050a1
+ * Copyright (c) 2012 John Resig, Jörn Zaefferer
+ * Dual licensed under the MIT (MIT-LICENSE.txt)
+ * or GPL (GPL-LICENSE.txt) licenses.
  */
 
 (function( window ) {

--- a/pavlov.js
+++ b/pavlov.js
@@ -515,9 +515,6 @@
 
         // set the test suite title
         name += " Specifications";
-        if (typeof document !== 'undefined') {
-            document.title = name + ' - Pavlov - ' + adapter.name;
-        }
 
         // run the adapter initiation
         adapter.initiate(name);
@@ -623,8 +620,12 @@
 
     pavlov.adapt("QUnit", {
         initiate: function (name) {
-            // after suite loads, set the header on the report page
+            // after suite loads, set title and header on the report page
             QUnit.addEvent(window, 'load', function () {
+                if (typeof document !== 'undefined') {
+                    document.title = name + ' - Pavlov - QUnit';
+                }
+
                 var h1s = document.getElementsByTagName('h1');
                 if (h1s.length > 0) {
                     h1s[0].innerHTML = name;

--- a/pavlov.js
+++ b/pavlov.js
@@ -623,17 +623,8 @@
 
     pavlov.adapt("QUnit", {
         initiate: function (name) {
-            var addEvent = function (elem, type, fn) {
-                if (elem.addEventListener) {
-                    elem.addEventListener(type, fn, false);
-                } else if (elem.attachEvent) {
-                    elem.attachEvent("on" + type, fn);
-                }
-            };
-
             // after suite loads, set the header on the report page
-            addEvent(window,'load',function () {
-                // document.getElementsByTag('h1').innerHTML = name;
+            QUnit.addEvent(window, 'load', function () {
                 var h1s = document.getElementsByTagName('h1');
                 if (h1s.length > 0) {
                     h1s[0].innerHTML = name;

--- a/spec/pavlov.specs.html
+++ b/spec/pavlov.specs.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
-<head>
-<script type="text/javascript" src="../lib/qunit.js"></script>
-<link rel="stylesheet" href="../lib/qunit.css" type="text/css" media="screen" />
-<script type="text/javascript" src="../pavlov.js"></script>
-<script type="text/javascript" src="pavlov.specs.js"></script>
-</head>
-<body>
-    <h1 id="qunit-header"></h1>
-    <h2 id="qunit-banner"></h2>
-    <div id="qunit-testrunner-toolbar"></div>
-    <h2 id="qunit-userAgent"></h2>
-    <ol id="qunit-tests"></ol>
-</body>
+    <head>
+        <script type="text/javascript" src="../lib/qunit.js"></script>
+        <link rel="stylesheet" href="../lib/qunit.css" type="text/css" media="screen" />
+        <script type="text/javascript" src="../pavlov.js"></script>
+        <script type="text/javascript" src="pavlov.specs.js"></script>
+    </head>
+    <body>
+        <h1 id="qunit-header"></h1>
+        <h2 id="qunit-banner"></h2>
+        <div id="qunit-testrunner-toolbar"></div>
+        <h2 id="qunit-userAgent"></h2>
+        <ol id="qunit-tests"></ol>
+    </body>
 </html>

--- a/spec/pavlov.specs.html
+++ b/spec/pavlov.specs.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script type="text/javascript" src="../lib/qunit.js"></script>
         <link rel="stylesheet" href="../lib/qunit.css" type="text/css" media="screen" />
-        <script type="text/javascript" src="../pavlov.js"></script>
-        <script type="text/javascript" src="pavlov.specs.js"></script>
     </head>
     <body>
         <h1 id="qunit-header"></h1>
@@ -12,5 +9,9 @@
         <div id="qunit-testrunner-toolbar"></div>
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
+
+        <script type="text/javascript" src="../lib/qunit.js"></script>
+        <script type="text/javascript" src="../pavlov.js"></script>
+        <script type="text/javascript" src="pavlov.specs.js"></script>
     </body>
 </html>

--- a/spec/pavlov.specs.js
+++ b/spec/pavlov.specs.js
@@ -56,6 +56,12 @@ var global = this;
         contentsEqual: function(actual, expected, message){
             var areEqual = contentsEqual(actual, expected);
             pavlov.adapter.assert(areEqual, message);
+        },
+        /**
+         * Asserts actual string contains the expected string (case sensitive)
+         */
+        contains: function (actual, expected, message) {
+            pavlov.adapter.assert(actual.indexOf(expected) >= 0, message);
         }
     });
 }())
@@ -1050,7 +1056,7 @@ pavlov.specify("Pavlov", function() {
             it("should update heading to suite name", function(){
                 var h1s = document.getElementsByTagName('h1');
                 if(h1s && h1s.length > 0) {
-                    assert(h1s[0].innerHTML).equals('Pavlov Specifications');
+                    assert(h1s[0].innerHTML).contains('Pavlov Specifications');
                 }
             });
         });

--- a/spec/pavlov.specs.js
+++ b/spec/pavlov.specs.js
@@ -90,7 +90,7 @@ pavlov.specify("Pavlov", function() {
 
     describe("version", function(){
         it("should return the current version", function(){
-            assert(pavlov.version).equals('0.3.0pre');
+            assert(pavlov.version).equals('0.4.0pre');
         });
     });
 


### PR DESCRIPTION
- Fix unit tests (now pass in simulated IE7 and IE8 as well)
- Move browser window manipulation (title and header name setting) to `adapter.initiate`
  - Test pages that contain _mix_ of traditional `QUnit` and `pavlov` tests can now prevent page title and header hijacking by using:
    
    ``` js
    pavlov.adapt('QUnit with original document', { initiate: function () {} });
    pavlov.specify(...);
    ```
