### PR TITLE
Extend throwsException() assertion to handle testing against error objects

### DIFF
--- a/pavlov.js
+++ b/pavlov.js
@@ -281,16 +281,25 @@
         isNotFunction: function (actual, message) {
             return adapter.assert(typeof actual !== "function", message);
         },
-        throwsException: function (actual, expectedErrorDescription, message) {
-            // can optionally accept expected error message
+        throwsException: function (actual, expectedError, message) {
+            // can optionally accept expected error message string or object
             try {
                 actual();
                 adapter.assert(false, message);
             } catch (e) {
-                // so, this bit of weirdness is basically a way to allow for the fact
-                // that the test may have specified a particular type of error to catch, or not.
-                // and if not, e would always === e.
-                adapter.assert(e === (expectedErrorDescription || e), message);
+                if (expectedError === undefined) {
+                    // e always === e so assertion always passes
+                    adapter.assert(e === e, message);
+                } else if (typeof e === 'string') {
+                    adapter.assert(e === expectedError, message);
+                } else if (typeof e === 'object') {
+                    if (typeof expectedError === 'object') {
+                        adapter.assert(e.name === expectedError.name && e.message === expectedError.message, message);
+                    } else if(typeof expectedError === 'string')  {
+                        adapter.assert(e.message === expectedError, message);
+                    }
+                }
+
             }
         }
     });

--- a/spec/pavlov.specs.js
+++ b/spec/pavlov.specs.js
@@ -907,6 +907,54 @@ pavlov.specify("Pavlov", function() {
                 // verify correct arguments would have been passed to qunit
                 assert(passedArgs).contentsEqual([false,"message"]);
             });
+
+            it("should pass true to adapter's assert when function throws exception object with expected message", function(){
+                var passedArgs = mock(pavlov.adapter, 'assert', function(){
+                    // run spec assertion while underlying qunit assertion is mocked
+                    assert(function(){
+                        throw(new Error("expected message"));
+                    }).throwsException("expected message", "message");
+                });
+
+                // verify correct arguments would have been passed to qunit
+                assert(passedArgs).contentsEqual([true,"message"]);
+            });
+
+            it("should pass true to adapter's assert when function throws exception object with expected error object", function(){
+                var passedArgs = mock(pavlov.adapter, 'assert', function(){
+                    // run spec assertion while underlying qunit assertion is mocked
+                    assert(function(){
+                        throw(new Error("expected message"));
+                    }).throwsException(new Error("expected message"), "message");
+                });
+
+                // verify correct arguments would have been passed to qunit
+                assert(passedArgs).contentsEqual([true,"message"]);
+            });
+
+            it("should pass false to adapter's assert when function throws exception object with unexpected error object name", function(){
+                var passedArgs = mock(pavlov.adapter, 'assert', function(){
+                    // run spec assertion while underlying qunit assertion is mocked
+                    assert(function(){
+                        throw(new SyntaxError("expected message"));
+                    }).throwsException(new Error("expected message"), "message");
+                });
+
+                // verify correct arguments would have been passed to qunit
+                assert(passedArgs).contentsEqual([false,"message"]);
+            });
+
+            it("should pass false to adapter's assert when function throws exception object with unexpected error object message", function(){
+                var passedArgs = mock(pavlov.adapter, 'assert', function(){
+                    // run spec assertion while underlying qunit assertion is mocked
+                    assert(function(){
+                        throw(new Error("some other error message"));
+                    }).throwsException(new Error("expected message"), "message");
+                });
+
+                // verify correct arguments would have been passed to qunit
+                assert(passedArgs).contentsEqual([false,"message"]);
+            });
         });
 
         describe("custom assertions", function(){


### PR DESCRIPTION
Does what it say on the tin really; I've extended `throwsException()` so that you can pass it an error object against which the actual exception is compared.

e.g.

``` javascript
assert(function(){
    throw(new SyntaxError("expected message"));
}).throwsException(new SyntaxError("expected message"));
```

Equality is determined by comparing the error `name` and `message`. See specs for additional examples.
