### PR TITLE
Properly order asynchronous `before` & `after`

### DIFF
--- a/pavlov.js
+++ b/pavlov.js
@@ -684,10 +684,10 @@
                 statements.push(function () {
                     module(example.names(), {
                         setup: function () {
-                            each(befores, function () { this(); });
+                            QUnit.config.queue = befores.concat(QUnit.config.queue);
                         },
                         teardown: function () {
-                            each(afters, function () { this(); });
+                            QUnit.config.queue = QUnit.config.queue.concat(afters);
                         }
                     });
                 });


### PR DESCRIPTION
`before` and `after` handlers can be asynchronous, and they need to run
in series.
